### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.7"
 dist: xenial
 sudo: true
 cache: pip


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__.

https://github.com/CheckPointSW/Karta/search?q=xrange