### PR TITLE
fix(disas/db) explicitly set ida database file name

### DIFF
--- a/src/disassembler/IDA/ida_cmd_api.py
+++ b/src/disassembler/IDA/ida_cmd_api.py
@@ -41,10 +41,11 @@ class IdaCMD(DisasCMD):
         """
         type = "elf" if not is_windows else "coff"
         suffix = ".i64" if self._path.endswith("64") else ".idb"
+        database_file = binary_file + suffix
         # execute the program
-        os.system("%s -A -B -T%s %s" % (self._path, type, binary_file))
+        os.system("%s -A -B -T%s -o%s %s" % (self._path, type, database_file, binary_file))
         # return back the (should be) created database file path
-        return binary_file + suffix
+        return database_file
 
     # Overridden base function
     def executeScript(self, database, script):


### PR DESCRIPTION
ida64 6.9 (tested on linux so far) removes the original file extension from the generated database path.
Example: `/some/path/foobar.so` --> `/some/path/foobar.i64`. This causes the analysis script to be executed on a non-existing ida database (`/some/path/foobar.so.i64`).

This commit changes so that the generated database name is specified as an output database name (`-o`) in the createDatabase command.