### PR TITLE
Robustness fix for karta_analyze_src.py

### DIFF
--- a/docs/Compiling a configuration.md
+++ b/docs/Compiling a configuration.md
@@ -37,6 +37,8 @@ optional arguments:
   -W, --windows     signals that the binary was compiled for Windows
 ```
 
+**Note:** The script must be executed from Karta's src directory.
+
 1.  Name of the open source library (case sensitive)
 1.  Version of the library (as will be identified by the identifier script)
 1.  Path to the directory that contains the compiled (*.o / *.obj) files

--- a/src/karta_analyze_src.py
+++ b/src/karta_analyze_src.py
@@ -293,6 +293,12 @@ def main(args):
     if is_windows:
         setWindowsMode()
 
+    # Check if launched from the src directory
+    if not os.path.exists(SCRIPT_PATH):
+        prompter.error('The script should be executed from Karta\'s src directory!')
+        prompter.error('Exiting')
+        return
+
     # analyze the open source library
     analyzeLibrary(constructConfigPath(library_name, library_version), bin_dirs, archive_paths, prompter)
 


### PR DESCRIPTION
karta_analyze_src.py should only be invoked from the src directory.