### PR TITLE
fix(disa/ida) use BasicBlock.endEA instead of .end_ea

### DIFF
--- a/src/disassembler/IDA/ida_analysis_api.py
+++ b/src/disassembler/IDA/ida_analysis_api.py
@@ -228,7 +228,7 @@ class AnalyzerIDA(object):
         func = sark.Function(func_ea)
         flow = idaapi.FlowChart(func.func_t)
         for block in flow:
-            if range_start <= block.startEA and block.end_ea <= range_end:
+            if range_start <= block.startEA and block.endEA <= range_end:
                 if island_guess is None or block.startEA < island_guess.startEA:
                     island_guess = block
         # quit if found nothing
@@ -246,7 +246,7 @@ class AnalyzerIDA(object):
                 if candidate_block in island_blocks:
                     continue
                 island_blocks.append(candidate_block)
-                new_candidate_list += filter(lambda succs: range_start <= succs.startEA and succs.end_ea <= range_end, candidate_block.succs())
+                new_candidate_list += filter(lambda succs: range_start <= succs.startEA and succs.endEA <= range_end, candidate_block.succs())
             candidate_list = new_candidate_list
         # return the results
         return island_blocks


### PR DESCRIPTION
I encountered a crash running karta_matcher on ida6.9 (linux) with the error: `'BasicBlock' object has no attribute 'end_ea'`.

Testing locally I found that a BasicBlock only have `endEA` and `startEA`, also example online use these variables.

edit: https://www.hex-rays.com/products/ida/support/idapython_docs/ida_gdl.BasicBlock-class.html