### PR TITLE
[Bug Fix] Use activeCodeTypes() instead of codeTypes()

### DIFF
--- a/src/thumbs_up/utils/function.py
+++ b/src/thumbs_up/utils/function.py
@@ -410,7 +410,7 @@ class FunctionClassifier():
         """
         # Nothing to check if there is only one type
         if not self._analyzer.hasActiveCodeTypes():
-            return self._analyzer.codeTypes()[0]
+            return self._analyzer.activeCodeTypes()[0]
         # Multiple types, now predict the right one
         sample = self.extractFunctionTypeSample(ea)
         return int(self._type_classifier.predict([sample]))


### PR DESCRIPTION
Used the wrong function when handled a single active code type. Fixes issue #41.